### PR TITLE
fix: put the color class name on the icon and not the container

### DIFF
--- a/packages/flipper-plugin-android-performance-profiler/src/__tests__/__snapshots__/Plugin.ts.snap
+++ b/packages/flipper-plugin-android-performance-profiler/src/__tests__/__snapshots__/Plugin.ts.snap
@@ -270,7 +270,7 @@ exports[`displays FPS data and scoring 2`] = `
         >
           <button
             aria-haspopup="true"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium text-neutral-300 css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
             id="export-menu-button"
             style="float: right;"
             tabindex="0"
@@ -278,7 +278,7 @@ exports[`displays FPS data and scoring 2`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit text-neutral-300 css-1vooibu-MuiSvgIcon-root"
               data-testid="MoreVertIcon"
               focusable="false"
               viewBox="0 0 24 24"

--- a/packages/web-reporter-ui/__tests__/__snapshots__/ReporterView.test.tsx.snap
+++ b/packages/web-reporter-ui/__tests__/__snapshots__/ReporterView.test.tsx.snap
@@ -647,7 +647,7 @@ exports[`<ReporterView /> renders the comparison view 2`] = `
     >
       <button
         aria-haspopup="true"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium text-neutral-300 css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
         id="export-menu-button"
         style="float: right;"
         tabindex="0"
@@ -655,7 +655,7 @@ exports[`<ReporterView /> renders the comparison view 2`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit text-neutral-300 css-1vooibu-MuiSvgIcon-root"
           data-testid="MoreVertIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -11698,7 +11698,7 @@ exports[`<ReporterView /> renders the comparison view 4`] = `
     >
       <button
         aria-haspopup="true"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium text-neutral-300 css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
         id="export-menu-button"
         style="float: right;"
         tabindex="0"
@@ -11706,7 +11706,7 @@ exports[`<ReporterView /> renders the comparison view 4`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit text-neutral-300 css-1vooibu-MuiSvgIcon-root"
           data-testid="MoreVertIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -17503,7 +17503,7 @@ exports[`<ReporterView /> renders the comparison view with videos 2`] = `
     >
       <button
         aria-haspopup="true"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium text-neutral-300 css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
         id="export-menu-button"
         style="float: right;"
         tabindex="0"
@@ -17511,7 +17511,7 @@ exports[`<ReporterView /> renders the comparison view with videos 2`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit text-neutral-300 css-1vooibu-MuiSvgIcon-root"
           data-testid="MoreVertIcon"
           focusable="false"
           viewBox="0 0 24 24"

--- a/packages/web-reporter-ui/src/components/Header.tsx
+++ b/packages/web-reporter-ui/src/components/Header.tsx
@@ -32,12 +32,11 @@ const Header = ({ saveToZIPCallBack }: { saveToZIPCallBack: () => void }) => {
         aria-haspopup="true"
         aria-expanded={open ? "true" : undefined}
         onClick={handleClick}
-        className="text-neutral-300"
         style={{
           float: "right",
         }}
       >
-        <MoreIcon fontSize="inherit" />
+        <MoreIcon fontSize="inherit" className="text-neutral-300" />
       </IconButton>
       <Menu
         id="export"


### PR DESCRIPTION
I don't why but it seems that the classnames from MUI was overriding the classname from tailwind on the parent. But when putting the tailwind classname on the icon itself it's not overridden 🙃 

So, to remember : the dev should be always putting the `fill-color-00` or `stroke-color-00` on the svg itself (as low as possible)


I still don't know why it was working here but not in flashlight-cloud