### PR TITLE
fix(measure): ensure we have only one socket connection between web & cli

### DIFF
--- a/packages/measure/src/webapp/socket.ts
+++ b/packages/measure/src/webapp/socket.ts
@@ -3,3 +3,5 @@ import { ServerToClientEvents, ClientToServerEvents } from "../server/socket/soc
 
 export const socket: Socket<ServerToClientEvents, ClientToServerEvents> =
   io("http://localhost:3000/");
+
+socket.on("disconnect", () => socket.close());


### PR DESCRIPTION
Since `flashlight measure` opens a new webapp on a new tab everytime, we want to make sure this one is the only one connected to the cli, so we completely close any previous webapp connection when it gets disconnected

Otherwise, this scenario can happen:
- I run `flashlight measure`, opening tab 1 
- i cancel the command
- I run `flashlight measure` again, opening a new tab
- the new tab connects to the CLI
- then the previous tab connects as well, and since we only allow one socket connection, the new tab we're using gets disconnected <= this is what we want to prevent

it would be possible to handle having multiple web apps connected to the socket, but for now it's just easier to manage this way