### PR TITLE
Feat/cpu usage per thread ios

### DIFF
--- a/packages/reporter/src/reporting/averageIterations.ts
+++ b/packages/reporter/src/reporting/averageIterations.ts
@@ -5,6 +5,7 @@ import {
   TestCaseIterationResult,
   TestCaseResult,
   ThreadNames,
+  ThreadNamesIOS,
 } from "@perf-profiler/types";
 import { mapValues } from "lodash";
 import { getHighCpuUsageStats } from "./reporting";
@@ -67,7 +68,9 @@ export const averageTestCaseResult = (result: TestCaseResult): AveragedTestCaseR
     average: averagedIterations,
     averageHighCpuUsage: averageHighCpuUsage(result.iterations),
     reactNativeDetected: averagedIterations.measures.some((measure) =>
-      Object.keys(measure.cpu.perName).some((key) => key === ThreadNames.JS_THREAD)
+      Object.keys(measure.cpu.perName).some(
+        (key) => key === ThreadNames.JS_THREAD || key === ThreadNamesIOS.JS_THREAD
+      )
     ),
   };
 };

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -29,12 +29,14 @@ export interface TestCaseIterationResult {
 }
 
 export type TestCaseResultStatus = "SUCCESS" | "FAILURE"; // Todo: add "SUCCESS_WITH_SOME_ITERATIONS_FAILED"
+
+type TestCaseResultType = "IOS_EXPERIMENTAL" | undefined;
 export interface TestCaseResult {
   name: string;
   score?: number;
   status: TestCaseResultStatus;
   iterations: TestCaseIterationResult[];
-  type?: undefined | "IOS_EXPERIMENTAL";
+  type?: TestCaseResultType;
 }
 
 export interface AveragedTestCaseResult {
@@ -45,6 +47,7 @@ export interface AveragedTestCaseResult {
   average: TestCaseIterationResult;
   averageHighCpuUsage: { [processName: string]: number };
   reactNativeDetected: boolean;
+  type?: TestCaseResultType;
 }
 
 // Shouldn't really be here but @perf-profiler/types is imported by everyone and doesn't contain any logic
@@ -54,4 +57,9 @@ export const POLLING_INTERVAL = 500;
 export const ThreadNames = {
   UI_THREAD: "UI Thread",
   JS_THREAD: "mqt_js",
+};
+
+export const ThreadNamesIOS = {
+  UI_THREAD: "Main Thread",
+  JS_THREAD: "com.facebook.react.JavaScript",
 };

--- a/packages/web-reporter-ui/src/sections/CPUReport.tsx
+++ b/packages/web-reporter-ui/src/sections/CPUReport.tsx
@@ -4,6 +4,7 @@ import {
   Measure,
   POLLING_INTERVAL,
   ThreadNames,
+  ThreadNamesIOS,
 } from "@perf-profiler/types";
 import { getAverageCpuUsage } from "@perf-profiler/reporter";
 import { Chart } from "../components/Chart";
@@ -32,8 +33,13 @@ const perThreadCpuAnnotationInterval = [{ y: 90, y2: 100, color: "#E62E2E", labe
 
 export const CPUReport = ({ results }: { results: AveragedTestCaseResult[] }) => {
   const reactNativeDetected = results.every((result) => result.reactNativeDetected);
+
+  const platformThreadNames = results.every((result) => result.type === "IOS_EXPERIMENTAL")
+    ? ThreadNamesIOS
+    : ThreadNames;
+
   const [selectedThreads, setSelectedThreads] = React.useState<string[]>(
-    reactNativeDetected ? [ThreadNames.JS_THREAD] : [ThreadNames.UI_THREAD]
+    reactNativeDetected ? [platformThreadNames.JS_THREAD] : [platformThreadNames.UI_THREAD]
   );
 
   const threads = selectedThreads

--- a/packages/web-reporter/writeReport.ts
+++ b/packages/web-reporter/writeReport.ts
@@ -91,9 +91,7 @@ export const writeReport = ({
 
   const isIOSTestCaseResult = results.every((result) => result.type === "IOS_EXPERIMENTAL");
 
-  const report = JSON.stringify(
-    isIOSTestCaseResult ? results : getMeasuresForTimeInterval({ results, skip, duration })
-  );
+  const report = JSON.stringify(getMeasuresForTimeInterval({ results, skip, duration }));
 
   const jsFileContent = fs.readFileSync(`${__dirname}/${scriptName}`, "utf8").replace(
     // See App.tsx for the reason why we do this


### PR DESCRIPTION
Add details about the cpu usage per thread.

## Tests: 
- Edit the file `packages/ios-poc/src/writeReport.ts` to put TIME_INTERVAL to 10 so that the report will be the same as the `.trace` created by xcode.
- Launch : `yarn workspace flashlight-ios-poc flashlight-ios-poc ios-test --appId org.reactjs.native.example.fakeStore --simulatorId 1C1F5B46-1BEB-4F91-9C95-C5196062E388 --testCommand 'maestro test ./test.yaml' --resultsFilePath 'result.json'` and then `node packages/web-reporter/dist/openReport.js report ./packages/ios-poc/result.json` and compare the result with the `.trace` that is created.
- Launch the same first command but with a different output and then `node packages/web-reporter/dist/openReport.js report ./packages/ios-poc/result.json <theOtherOutput>` to compare reports.
- Launch `node packages/web-reporter/dist/openReport.js report ./packages/ios-poc/result.json <theOtherOutput> -s 500 -d 1000` to ensure that the conditional check removed was indeed useless.
- Reset TIME_INTERVAL to 500