### PR TITLE
chore: fix e2e Android ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "lerna": "^4.0.0",
-    "lint-staged": ">=10",
+    "lint-staged": "13.0.3",
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "typescript": "^4.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8632,7 +8632,7 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-lint-staged@>=10:
+lint-staged@13.0.3:
   version "13.0.3"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.0.3.tgz#d7cdf03a3830b327a2b63c6aec953d71d9dc48c6"
   integrity sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==


### PR DESCRIPTION
lint-staged newer versions require node 18. 
Not an ideal fix, however:

We run `npm-bundle` on the whole repo before sending it to AWS as per their doc, however it seems it doesn't package installed dependencies as expected. Since the lock file isn't included, we reinstall all deps on AWS, hence hitting an issue

Note that installing node 18 on AWS Device farm machines fails with error: node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by node)