### PR TITLE
chore: upgrade lerna

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "husky": ">=6",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "lerna": "^4.0.0",
+    "lerna": "^8.0.0",
     "lint-staged": "13.0.3",
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",


### PR DESCRIPTION
This PR upgrades lerna version, in order to upgrade to node 18.