### PR TITLE
fix(measure): UI buttons unresponsive/streamline socket URL handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -49,6 +49,6 @@ module.exports = {
     ...commonOptions,
     displayName: name,
     testEnvironment,
-    testMatch: [`<rootDir>/packages/${name}/**/__tests__/*.{ts,tsx}`],
+    testMatch: [`<rootDir>/packages/${name}/**/__tests__/**/*.{ts,tsx}`],
   })),
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,12 @@
 const commonOptions = {
   transform: {
-    "^.+\\.tsx?$": "ts-jest",
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        // we already get TS errors with tsc, so no need to have them here
+        diagnostics: false,
+      },
+    ],
   },
   testPathIgnorePatterns: [
     "\\.snap$",

--- a/packages/commands/measure/package.json
+++ b/packages/commands/measure/package.json
@@ -30,11 +30,13 @@
     "@perf-profiler/web-reporter-ui": "^0.14.0",
     "@testing-library/react": "^12.1.1",
     "@types/express": "^4.17.17",
+    "@types/supertest": "^6.0.2",
     "ink-testing-library": "^2.1.0",
     "parcel": "^2.7.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "socket.io-client": "^4.7.0"
+    "socket.io-client": "^4.7.0",
+    "supertest": "^6.3.4"
   },
   "scripts": {
     "build": "yarn parcel build src/webapp/index.html",

--- a/packages/commands/measure/src/__tests__/measure.test.tsx
+++ b/packages/commands/measure/src/__tests__/measure.test.tsx
@@ -6,7 +6,6 @@ import {
 } from "@perf-profiler/e2e/src/utils/test/mockEmitMeasures";
 import { fireEvent, render as webRender, screen, waitFor, act } from "@testing-library/react";
 import { render as cliRender } from "ink-testing-library";
-import { MeasureWebApp } from "../webapp/MeasureWebApp";
 import React from "react";
 import { ServerApp } from "../server/ServerApp";
 import { open } from "@perf-profiler/shell";
@@ -24,7 +23,26 @@ Math.random = () => 0.5;
 // Set me to LogLevel.DEBUG to see the debug logs
 Logger.setLogLevel(LogLevel.SILENT);
 
+let originalWindow: Window & typeof globalThis;
+let MeasureWebApp: React.FC;
+
 describe("flashlight measure interactive", () => {
+  beforeAll(async () => {
+    originalWindow = global.window;
+
+    global.window = Object.create(window);
+    Object.defineProperty(window, "__FLASHLIGHT_DATA__", {
+      value: { socketServerUrl: `http://localhost:${DEFAULT_PORT}` },
+      writable: true,
+    });
+
+    MeasureWebApp = (await import("../webapp/MeasureWebApp")).MeasureWebApp;
+  });
+
+  afterAll(() => {
+    global.window = originalWindow;
+  });
+
   const expectWebAppToBeOpened = () =>
     waitFor(() => expect(open).toHaveBeenCalledWith(`http://localhost:${DEFAULT_PORT}`));
 

--- a/packages/commands/measure/src/__tests__/server/ServerApp.test.ts
+++ b/packages/commands/measure/src/__tests__/server/ServerApp.test.ts
@@ -1,0 +1,42 @@
+import supertest from "supertest";
+import express from "express";
+import fs from "fs";
+
+import { createExpressApp } from "../../server/ServerApp";
+import type { FlashlightData } from "../../common/types";
+
+jest.mock("fs", () => ({
+  promises: {
+    readFile: jest.fn(),
+  },
+}));
+
+describe("ServerApp", () => {
+  let app: express.Express;
+  const injected: FlashlightData = { socketServerUrl: "http://localhost:9999" };
+
+  beforeAll(() => {
+    jest.spyOn(express, "static").mockImplementation(() => (req, res, next) => next());
+  });
+
+  beforeEach(() => {
+    (fs.promises.readFile as jest.Mock).mockResolvedValue("<html>/* %FLASHLIGHT_DATA% */</html>");
+
+    app = createExpressApp(injected);
+  });
+
+  describe("GET /", () => {
+    it("injects FlashlightData into index.html", async () => {
+      const response = await supertest(app).get("/");
+
+      expect(response.statusCode).toBe(200);
+      expect(response.text).toContain(`window.__FLASHLIGHT_DATA__ = ${JSON.stringify(injected)};`);
+    });
+  });
+
+  test("index.html contains the FlashlightData placeholder", async () => {
+    const fsPromises = jest.requireActual("fs").promises;
+    const fileContent = await fsPromises.readFile(`${__dirname}/../../webapp/index.html`, "utf8");
+    expect(fileContent).toContain("/* %FLASHLIGHT_DATA% */");
+  });
+});

--- a/packages/commands/measure/src/__tests__/webapp/socket.test.ts
+++ b/packages/commands/measure/src/__tests__/webapp/socket.test.ts
@@ -1,0 +1,37 @@
+import { io } from "socket.io-client";
+
+jest.mock("socket.io-client", () => {
+  return {
+    ...jest.requireActual("socket.io-client"),
+    io: jest.fn().mockImplementation(() => {
+      return {
+        on: jest.fn(),
+        close: jest.fn(),
+      };
+    }),
+  };
+});
+
+let originalWindow: Window & typeof globalThis;
+
+describe("socket", () => {
+  beforeAll(async () => {
+    originalWindow = global.window;
+
+    global.window = Object.create(window);
+    Object.defineProperty(window, "__FLASHLIGHT_DATA__", {
+      value: { socketServerUrl: "http://localhost:9999" },
+      writable: true,
+    });
+  });
+
+  afterAll(() => {
+    // Restore the original window object
+    global.window = originalWindow;
+  });
+
+  it("sets the expected socket server URL", async () => {
+    await import("../../webapp/socket");
+    expect(io).toHaveBeenCalledWith("http://localhost:9999");
+  });
+});

--- a/packages/commands/measure/src/common/types/index.d.ts
+++ b/packages/commands/measure/src/common/types/index.d.ts
@@ -1,0 +1,3 @@
+export interface FlashlightData {
+  socketServerUrl: string;
+}

--- a/packages/commands/measure/src/server/ServerApp.tsx
+++ b/packages/commands/measure/src/server/ServerApp.tsx
@@ -16,7 +16,7 @@ import type { FlashlightData } from "../common/types";
 
 const pathToDist = path.join(__dirname, "../../dist");
 
-const createExpressApp = (injected: FlashlightData) => {
+export const createExpressApp = (injected: FlashlightData) => {
   const app = express();
   app.use(cors({ origin: true }));
 

--- a/packages/commands/measure/src/server/ServerApp.tsx
+++ b/packages/commands/measure/src/server/ServerApp.tsx
@@ -1,5 +1,7 @@
 import express from "express";
 import http from "http";
+import { promises as fs } from "fs";
+import path from "path";
 import cors from "cors";
 import { Server } from "socket.io";
 import { open } from "@perf-profiler/shell";
@@ -10,18 +12,35 @@ import { getWebAppUrl } from "./constants";
 import { ServerSocketConnectionApp } from "./ServerSocketConnectionApp";
 import { useInput } from "ink";
 import { profiler } from "@perf-profiler/profiler";
+import type { FlashlightData } from "../common/types";
 
-const createExpressApp = () => {
+const pathToDist = path.join(__dirname, "../../dist");
+
+const createExpressApp = (injected: FlashlightData) => {
   const app = express();
   app.use(cors({ origin: true }));
+
+  app.get("/", async (_, res) => {
+    try {
+      const indexHtml = path.join(pathToDist, "index.html");
+      let data = await fs.readFile(indexHtml, "utf8");
+      data = data.replace(
+        "/* %FLASHLIGHT_DATA% */",
+        `window.__FLASHLIGHT_DATA__ = ${JSON.stringify(injected)};`
+      );
+      res.send(data);
+    } catch (err) {
+      res.status(500).send("Error loading the page");
+    }
+  });
+
   // Serve the webapp folder built by parcel
-  app.use(express.static(`${__dirname}/../../dist`));
+  app.use(express.static(pathToDist));
   return app;
 };
 
 const allowOnlyOneSocketClient = (io: SocketServer, onConnect: (socket: SocketType) => void) => {
   let currentSocketClient: SocketType | null = null;
-
   io.on("connection", (socket) => {
     currentSocketClient?.disconnect(true);
     onConnect(socket);
@@ -48,7 +67,7 @@ export const ServerApp = ({ port }: ServerAppProps) => {
   const [socket, setSocket] = useState<SocketType | null>(null);
   const webAppUrl = getWebAppUrl(port);
   useEffect(() => {
-    const app = createExpressApp();
+    const app = createExpressApp({ socketServerUrl: webAppUrl });
 
     const server = http.createServer(app);
     const io: SocketServer = new Server(server, {

--- a/packages/commands/measure/src/webapp/globals.d.ts
+++ b/packages/commands/measure/src/webapp/globals.d.ts
@@ -1,0 +1,9 @@
+import type { FlashlightData } from "../common/types";
+
+declare global {
+  interface Window {
+    __FLASHLIGHT_DATA__: FlashlightData;
+  }
+}
+
+export {};

--- a/packages/commands/measure/src/webapp/index.html
+++ b/packages/commands/measure/src/webapp/index.html
@@ -23,5 +23,8 @@
     </style>
     <div id="app"></div>
     <script type="module" src="index.js"></script>
+    <script>
+      /* %FLASHLIGHT_DATA% */
+    </script>
   </body>
 </html>

--- a/packages/commands/measure/src/webapp/socket.ts
+++ b/packages/commands/measure/src/webapp/socket.ts
@@ -1,7 +1,8 @@
 import { io, Socket } from "socket.io-client";
 import { ServerToClientEvents, ClientToServerEvents } from "../server/socket/socketInterface";
 
-export const socket: Socket<ServerToClientEvents, ClientToServerEvents> =
-  io("http://localhost:3000/");
+export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
+  window.__FLASHLIGHT_DATA__.socketServerUrl
+);
 
 socket.on("disconnect", () => socket.close());

--- a/yarn.lock
+++ b/yarn.lock
@@ -4332,6 +4332,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
+"@types/cookiejar@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
+  integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
+
 "@types/cors@^2.8.12":
   version "2.8.15"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.15.tgz#eb143aa2f8807ddd78e83cbff141bbedd91b60ee"
@@ -4453,6 +4458,11 @@
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.3.tgz#b2e20a9536f91ab3e6e7895c91883e1a7ad49a6e"
   integrity sha512-/BJF3NT0pRMuxrenr42emRUF67sXwcZCd+S1ksG/Fcf9O7C3kKCY4uJSbKBE4KDUIYr3WMsvfmWD8hRjXExBJQ==
+
+"@types/methods@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@types/methods/-/methods-1.1.4.tgz#d3b7ac30ac47c91054ea951ce9eed07b1051e547"
+  integrity sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==
 
 "@types/mime@*":
   version "3.0.3"
@@ -4595,6 +4605,23 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.2.tgz#01284dde9ef4e6d8cef6422798d9a3ad18a66f8b"
   integrity sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==
+
+"@types/superagent@^8.1.0":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-8.1.1.tgz#dbc620c5df3770b0c3092f947d6d5e808adae2bc"
+  integrity sha512-YQyEXA4PgCl7EVOoSAS3o0fyPFU6erv5mMixztQYe1bqbWmmn8c+IrqoxjQeZe4MgwXikgcaZPiI/DsbmOVlzA==
+  dependencies:
+    "@types/cookiejar" "^2.1.5"
+    "@types/methods" "^1.1.4"
+    "@types/node" "*"
+
+"@types/supertest@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-6.0.2.tgz#2af1c466456aaf82c7c6106c6b5cbd73a5e86588"
+  integrity sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==
+  dependencies:
+    "@types/methods" "^1.1.4"
+    "@types/superagent" "^8.1.0"
 
 "@types/tough-cookie@*":
   version "4.0.4"
@@ -5975,6 +6002,11 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
+component-emitter@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.1.tgz#ef1d5796f7d93f135ee6fb684340b26403c97d17"
+  integrity sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==
+
 compress-commons@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.2.tgz#6542e59cb63e1f46a8b21b0e06f9a32e4c8b06df"
@@ -6141,6 +6173,11 @@ cookie@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 core-js-compat@^3.31.0, core-js-compat@^3.33.1:
   version "3.33.2"
@@ -6553,7 +6590,7 @@ devtools@6.12.1:
     ua-parser-js "^0.7.21"
     uuid "^8.0.0"
 
-dezalgo@^1.0.0:
+dezalgo@^1.0.0, dezalgo@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
   integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
@@ -7367,6 +7404,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fast-xml-parser@4.2.5:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz#a6747a09296a6cb34f2ae634019bf1738f3b421f"
@@ -7522,6 +7564,16 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formidable@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.2.tgz#fa973a2bec150e4ce7cac15589d7a25fc30ebd89"
+  integrity sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==
+  dependencies:
+    dezalgo "^1.0.4"
+    hexoid "^1.0.0"
+    once "^1.4.0"
+    qs "^6.11.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -7939,6 +7991,11 @@ hasown@^2.0.0:
   integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
   dependencies:
     function-bind "^1.1.2"
+
+hexoid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
+  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
@@ -9768,7 +9825,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -9797,6 +9854,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -11113,7 +11175,7 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
-qs@^6.9.4:
+qs@^6.11.0, qs@^6.9.4:
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
   integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
@@ -11703,7 +11765,7 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
+semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -12273,6 +12335,30 @@ sucrase@^3.32.0:
     mz "^2.7.0"
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
+
+superagent@^8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.1.2.tgz#03cb7da3ec8b32472c9d20f6c2a57c7f3765f30b"
+  integrity sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.4"
+    debug "^4.3.4"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.0"
+    formidable "^2.1.2"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.11.0"
+    semver "^7.3.8"
+
+supertest@^6.3.4:
+  version "6.3.4"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.3.4.tgz#2145c250570c2ea5d337db3552dbfb78a2286218"
+  integrity sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^8.1.2"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
This PR is a follow-up to https://github.com/bamlab/flashlight/pull/186 addressing [this issue comment](https://github.com/bamlab/flashlight/pull/186#issuecomment-1893458782).

The issue was caused by the webapp connecting to a fixed socket server url (`http://localhost:3000`). To resolve this, we server-side render data into a (`__FLASHLIGHT_DATA__`) object, which is now available in the window context of the webapp. This change enables the webapp's socket client to connect to a dynamic server url.

A notable aspect of this change is its impact on unit testing, particularly for the `MeasureWebApp` component. Related tests now require setting up the `window.__FLASHLIGHT_DATA__` context _before_ importing `MeasureWebApp`. This is crucial because if `window.__FLASHLIGHT_DATA__.serverSocketUrl` is not initialized correctly, the webapp's socket connection will fail, leading to test failures that may not be immediately apparent. While this adds a layer of complexity to the initial testing approach, it's a necessary trade-off for the enhanced dynamism in the socket server connections.

https://github.com/bamlab/flashlight/pull/189