### PR TITLE
chore: fix aws CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-custom-rules": "link:./packages/eslint-plugin-flashlight-eslint-rules/dist",
     "eslint-plugin-import": "^2.26.0",
-    "husky": ">=6",
+    "husky": "^8.0.3",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "lerna": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,7 +8147,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@>=6:
+husky@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
   integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==


### PR DESCRIPTION
Since we install the whole project on AWS CI, we are faced with 2 issues:
- the yarn.lock file doesn't get packages when we push dependencies with npm-bundle
- AWS doesn't support node 18 so is still running Node 16

Husky v9 doesn't support node 16, so ensuring we install node 16 as a quick fix