### PR TITLE
feat: export FPS and RAM reporting

### DIFF
--- a/packages/core/reporter/src/index.ts
+++ b/packages/core/reporter/src/index.ts
@@ -4,4 +4,6 @@ export * from "./reporting/Report";
 export * from "./utils/sanitizeProcessName";
 export * from "./utils/round";
 export * from "./reporting/cpu";
+export * from "./reporting/ram";
+export * from "./reporting/fps";
 export { canComputeHighCpuUsage } from "./reporting/highCpu";


### PR DESCRIPTION
We are integrating `flashlisght` profiler to our e2e tests pipeline and we would like to capture average FPS and RAM usage.

So I'm exporting everything from these files as it was done with `cpu` file.