### PR TITLE
fix: don't crash profiler if we can not parse `FrameTime`

### DIFF
--- a/packages/platforms/android/src/commands/platforms/UnixProfiler.ts
+++ b/packages/platforms/android/src/commands/platforms/UnixProfiler.ts
@@ -136,7 +136,19 @@ export abstract class UnixProfiler implements Profiler {
         const subProcessesStats = processOutput(cpu, pid);
 
         const ram = processRamOutput(ramStr, this.getRAMPageSize());
-        const { frameTimes, interval: atraceInterval } = frameTimeParser.getFrameTimes(atrace, pid);
+
+        let output;
+        try {
+          output = frameTimeParser.getFrameTimes(atrace, pid);
+        } catch (e) {
+          console.error(e);
+        }
+
+        if (!output) {
+          return;
+        }
+
+        const { frameTimes, interval: atraceInterval } = output;
 
         if (!initialTime) {
           initialTime = timestamp;


### PR DESCRIPTION
In case if we can not parse `FrameTime` - we don't call `onMeasure` (instead of crashing a profiler).

Closes https://github.com/bamlab/flashlight/issues/291