### PR TITLE
Fix appium-helper's client code to run with Appium v2.0+ properly

### DIFF
--- a/packages/plugins/appium-helper/AppiumDriver.ts
+++ b/packages/plugins/appium-helper/AppiumDriver.ts
@@ -69,12 +69,12 @@ export class AppiumDriver {
     const capabilities = {
       platformName: "Android",
       "appium:automationName": "UiAutomator2",
-      appPackage,
+      "appium:appPackage": appPackage,
       // See https://github.com/appium/appium/blob/1e30207ec4e413c64396420fbb0388392e88cc54/docs/en/writing-running-appium/other/reset-strategies.md
       "appium:noReset": true,
-      autoLaunch: false,
-      appActivity,
-      newCommandTimeout: TEN_MINUTES,
+      "appium:autoLaunch": false,
+      "appium:appActivity": appActivity,
+      "appium:newCommandTimeout": TEN_MINUTES,
       ...clientCapabilities,
     };
 

--- a/packages/plugins/appium-helper/AppiumDriver.ts
+++ b/packages/plugins/appium-helper/AppiumDriver.ts
@@ -79,7 +79,7 @@ export class AppiumDriver {
     };
 
     const client = await webdriver.remote({
-      path: "/wd/hub",
+      path: "/",
       port: 4723,
       logLevel: "warn",
       capabilities,

--- a/packages/plugins/appium-helper/README.md
+++ b/packages/plugins/appium-helper/README.md
@@ -35,8 +35,8 @@ import { AppiumDriver } from "@bam.tech/appium-helper";
 test("e2e", async () => {
   const driver = await AppiumDriver.create({
     // `npx @perf-profiler/profiler getCurrentApp` will display info for the current app
-    appPackage: com.example,
-    appActivity: com.example.MainActivity,
+    appPackage: "com.example",
+    appActivity: "com.example.MainActivity",
   });
 
   driver.startApp();
@@ -44,7 +44,7 @@ test("e2e", async () => {
 });
 ```
 
-3. Run the appium server `npx appium` in a terminal
+3. Run the appium server `npx appium` in a terminal. If you just installed Appium, you may need to install a driver, e.g., by running `npx appium driver install uiautomator2`.
 4. Run your test file in a separate terminal `yarn jest appium.test.ts`
 
 ### API


### PR DESCRIPTION
# Description

Running tests that rely on the plugin strictly following the README steps causes us to face issues preventing us from properly creating an Appium driver session.

Some causes could relate to not installing drivers and compatibility issues using Appium 2.0. The client code seems to be outdated.

# Updates

* README updated to include instructions about the driver installation
* Fixed driver basepath by removing /wd/hub that doesn't exist anymore
* Fixed capabilities definition by adding the required vendor prefix

# Evidences

#### Current Appium installation

<img src="https://github.com/user-attachments/assets/2296a589-0241-4a26-918b-863313338f85" height="230" />

#### 404 for `/wd/hub`

| server console | test console |
| --------------- | ---------------- |
| ![Untitled (1)](https://github.com/user-attachments/assets/83f4c36d-dd67-41bf-add7-6326221a1b5d) | ![Untitled (2)](https://github.com/user-attachments/assets/8c194a71-6d94-4345-9f5d-017715fbb76b) |

#### Non-standard capabilities without prefix

| server console | test console |
| --------------- | ---------------- |
| ![Untitled (3)](https://github.com/user-attachments/assets/87f7c899-562c-4f2d-a2bd-dda5535405c4) | ![Untitled (4)](https://github.com/user-attachments/assets/271af0c1-e91e-4bac-8d30-c2c695102ad6) |

#### All fine after updates

<img src="https://github.com/user-attachments/assets/e24d0a68-6e5c-4224-bccb-5fb3146a565e" height="100" />